### PR TITLE
Add Laravel Version badge to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Laravel.io Pastebin
+# Laravel.io Pastebin - [![Laravel Version](https://shield.with.social/cc/github/laravelio/pastebin/master.svg?style=flat-square)](https://packagist.org/packages/laravel/framework)
 
 [![Build Status](https://travis-ci.org/laravelio/pastebin.svg?branch=master)](https://travis-ci.org/laravelio/pastebin)
 [![StyleCI](https://styleci.io/repos/80994622/shield?branch=master)](https://styleci.io/repos/80994622)

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Laravel.io Pastebin - [![Laravel Version](https://shield.with.social/cc/github/laravelio/pastebin/master.svg?style=flat-square)](https://packagist.org/packages/laravel/framework)
+# Laravel.io Pastebin
 
 [![Build Status](https://travis-ci.org/laravelio/pastebin.svg?branch=master)](https://travis-ci.org/laravelio/pastebin)
 [![StyleCI](https://styleci.io/repos/80994622/shield?branch=master)](https://styleci.io/repos/80994622)
@@ -6,6 +6,7 @@
 [![Test Coverage](https://lima.codeclimate.com/github/laravelio/pastebin/badges/coverage.svg)](https://lima.codeclimate.com/github/laravelio/pastebin/coverage)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/6c1df3e8-3e43-40c4-be31-65dfd9a2030b/mini.png)](https://insight.sensiolabs.com/projects/6c1df3e8-3e43-40c4-be31-65dfd9a2030b)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](license.txt)
+[![Laravel Version](https://shield.with.social/cc/github/laravelio/pastebin/master.svg?style=flat-square)](https://packagist.org/packages/laravel/framework)
 
 This is the repository for [the Laravel.io pastebin](https://paste.laravel.io). The code is entirely open source and licensed under [the MIT license](license.txt). Feel free to contribute to the pastebin by sending in a pull request.
 


### PR DESCRIPTION
Cache is 1 hour on the image. If you upgrade laravel/framework, it'll take up to an hour to update (plus GitHub cache).