### PR TITLE
Disallowed all paths, and allowed only the home page of pastebin #42

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
-Disallow:
+Disallow: /*
+Allow: /$


### PR DESCRIPTION
Since, all the pastes are stored at /{hash}. I have disallowed /* (all routes) and then allowed just the homepage. #42 